### PR TITLE
feat: cross-reference colour scheme + apply contributed token colours (v0.3.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "rxiv-maker" VS Code extension will be documented in 
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **🎨 Cross-reference label colouring** - The label after the colon in cross-references and label definitions (e.g. `blabla` in `@fig:blabla`, `@snote:blabla`, `{#fig:blabla}`) is now colour-coded. The grammar already scoped it (`variable.other.constant.reference.rxiv` / `…label.rxiv`); this adds an `editor.tokenColorCustomizations` rule via `contributes.configurationDefaults` so it renders distinctly regardless of the active theme.
+
 ## [0.3.15] - 2025-12-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 ## [Unreleased]
 
 ### Added
-- **🎨 Cross-reference label colouring** - The label after the colon in cross-references and label definitions (e.g. `blabla` in `@fig:blabla`, `@snote:blabla`, `{#fig:blabla}`) is now colour-coded. The grammar already scoped it (`variable.other.constant.reference.rxiv` / `…label.rxiv`); this adds an `editor.tokenColorCustomizations` rule via `contributes.configurationDefaults` so it renders distinctly regardless of the active theme.
+- **🎨 Cross-reference label colouring** - The label after the colon in cross-references and label definitions (e.g. `blabla` in `@fig:blabla`, `@snote:blabla`, `{#fig:blabla}`) is now colour-coded. The grammar already scoped it (`variable.other.constant.reference.rxiv` / `…label.rxiv`); this adds an `editor.tokenColorCustomizations` rule via `contributes.configurationDefaults` so it renders distinctly regardless of the active theme. Also reorders the grammar so the cross-reference rule precedes the generic citation rule, which previously shadowed `@type:label` uses (matching `@type` as a citation and leaving the label unscoped).
 
 ## [0.3.15] - 2025-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to the "rxiv-maker" VS Code extension will be documented in 
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.3.16] - 2026-05-29
 
 ### Added
-- **🎨 Cross-reference label colouring** - The label after the colon in cross-references and label definitions (e.g. `blabla` in `@fig:blabla`, `@snote:blabla`, `{#fig:blabla}`) is now colour-coded. The grammar already scoped it (`variable.other.constant.reference.rxiv` / `…label.rxiv`); this adds an `editor.tokenColorCustomizations` rule via `contributes.configurationDefaults` so it renders distinctly regardless of the active theme. Also reorders the grammar so the cross-reference rule precedes the generic citation rule, which previously shadowed `@type:label` uses (matching `@type` as a citation and leaving the label unscoped).
+- **🎨 Cross-reference colouring** - Cross-references and label definitions (`@fig:label`, `@sfig:label`, `@stable:label`, `@snote:label`, `{#fig:label}`) are now colour-coded via `editor.tokenColorCustomizations` contributed in `configurationDefaults`: the type, the `@`/`:` punctuation, and the supplementary `s` share one hue while the label uses another, so the token reads coherently. The supplementary `s` (in `@stable`/`@sfig`/`@seq`) no longer renders differently from `@snote`. Also reorders the grammar so the cross-reference rule precedes the generic citation rule, which previously shadowed `@type:label` uses (matching `@type` as a citation and leaving the label unscoped).
+
+### Fixed
+- **🔧 Apply contributed token colours** - Moved the `contributes.tokenColors` rules into `editor.tokenColorCustomizations` under `configurationDefaults`. `contributes.tokenColors` is not a supported VS Code contribution point and had no effect, so the intended colours for `<newpage>`, blindtext placeholders, and embedded Python/TeX blocks were never applied; they now render as authored.
 
 ## [0.3.15] - 2025-12-09
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,19 @@
     "configurationDefaults": {
       "[rxiv-markdown]": {
         "editor.wordWrap": "on"
+      },
+      "editor.tokenColorCustomizations": {
+        "textMateRules": [
+          {
+            "scope": [
+              "variable.other.constant.reference.rxiv",
+              "variable.other.constant.label.rxiv"
+            ],
+            "settings": {
+              "foreground": "#CE9178"
+            }
+          }
+        ]
       }
     },
     "grammars": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rxiv-maker",
   "displayName": "Rxiv-Maker",
   "description": "Enhanced toolkit for scientific manuscript authoring with rxiv-maker, including Python code execution, blindtext support, and comprehensive linting",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "publisher": "HenriquesLab",
   "icon": "icon.png",
   "license": "MIT",
@@ -70,13 +70,174 @@
         "textMateRules": [
           {
             "scope": [
+              "entity.name.type.reference.rxiv",
+              "entity.name.type.label.rxiv",
+              "keyword.other.supplementary.rxiv",
+              "entity.name.tag.reference.rxiv"
+            ],
+            "settings": {
+              "foreground": "#C586C0"
+            }
+          },
+          {
+            "scope": [
               "variable.other.constant.reference.rxiv",
               "variable.other.constant.label.rxiv"
             ],
             "settings": {
+              "foreground": "#D7BA7D"
+            }
+          },
+          {
+            "scope": [
+              "markup.subscript",
+              "markup.superscript"
+            ],
+            "settings": {
+              "foreground": "#A0A0A0"
+            }
+          },
+          {
+            "scope": "keyword.control.newpage.rxiv",
+            "settings": {
+              "foreground": "#569CD6"
+            }
+          },
+          {
+            "scope": "keyword.control.placeholder.blindtext.rxiv",
+            "settings": {
+              "foreground": "#C586C0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "entity.name.function.blindtext.rxiv",
+            "settings": {
+              "foreground": "#DCDCAA"
+            }
+          },
+          {
+            "scope": "keyword.control.embedded.python.rxiv",
+            "settings": {
+              "foreground": "#4EC9B0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.control.embedded.tex.rxiv",
+            "settings": {
+              "foreground": "#FF7F50",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "source.tex.embedded.rxiv",
+            "settings": {
+              "foreground": "#D4D4D4"
+            }
+          },
+          {
+            "scope": "punctuation.definition.embedded.begin.rxiv",
+            "settings": {
+              "foreground": "#4EC9B0"
+            }
+          },
+          {
+            "scope": "punctuation.definition.embedded.end.rxiv",
+            "settings": {
+              "foreground": "#4EC9B0"
+            }
+          },
+          {
+            "scope": "source.python.embedded.rxiv",
+            "settings": {
+              "foreground": "#D4D4D4"
+            }
+          },
+          {
+            "scope": "keyword.control.import.python.rxiv",
+            "settings": {
+              "foreground": "#C586C0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "entity.name.type.module.python.rxiv",
+            "settings": {
+              "foreground": "#4FC1FF"
+            }
+          },
+          {
+            "scope": "keyword.control.variable.set.python.rxiv",
+            "settings": {
+              "foreground": "#9CDCFE",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.control.variable.get.python.rxiv",
+            "settings": {
+              "foreground": "#DCDCAA",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.control.variable.global.python.rxiv",
+            "settings": {
+              "foreground": "#FF6B6B",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "variable.other.readwrite.python.rxiv",
+            "settings": {
+              "foreground": "#9CDCFE"
+            }
+          },
+          {
+            "scope": "variable.other.readwrite.global.python.rxiv",
+            "settings": {
+              "foreground": "#FF8C94"
+            }
+          },
+          {
+            "scope": "keyword.operator.assignment.python.rxiv",
+            "settings": {
+              "foreground": "#D4D4D4"
+            }
+          },
+          {
+            "scope": "string.quoted.context.name.python.rxiv",
+            "settings": {
               "foreground": "#CE9178"
             }
+          },
+          {
+            "scope": "string.quoted.format.spec.python.rxiv",
+            "settings": {
+              "foreground": "#D7BA7D"
+            }
+          },
+          {
+            "scope": "keyword.control.conditional.python.rxiv",
+            "settings": {
+              "foreground": "#C586C0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "string.quoted.double.conditional.python.rxiv",
+            "settings": {
+              "foreground": "#98C379"
+            }
+          },
+          {
+            "scope": "punctuation.separator.conditional.python.rxiv",
+            "settings": {
+              "foreground": "#D4D4D4"
+            }
           }
+    
         ]
       }
     },
@@ -85,157 +246,6 @@
         "language": "rxiv-markdown",
         "scopeName": "source.rxiv-markdown",
         "path": "./syntaxes/rxiv-markdown.tmLanguage.json"
-      }
-    ],
-    "tokenColors": [
-      {
-        "scope": [
-          "markup.subscript",
-          "markup.superscript"
-        ],
-        "settings": {
-          "foreground": "#A0A0A0"
-        }
-      },
-      {
-        "scope": "keyword.control.newpage.rxiv",
-        "settings": {
-          "foreground": "#569CD6"
-        }
-      },
-      {
-        "scope": "keyword.control.placeholder.blindtext.rxiv",
-        "settings": {
-          "foreground": "#C586C0",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "entity.name.function.blindtext.rxiv",
-        "settings": {
-          "foreground": "#DCDCAA"
-        }
-      },
-      {
-        "scope": "keyword.control.embedded.python.rxiv",
-        "settings": {
-          "foreground": "#4EC9B0",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "keyword.control.embedded.tex.rxiv",
-        "settings": {
-          "foreground": "#FF7F50",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "source.tex.embedded.rxiv",
-        "settings": {
-          "foreground": "#D4D4D4"
-        }
-      },
-      {
-        "scope": "punctuation.definition.embedded.begin.rxiv",
-        "settings": {
-          "foreground": "#4EC9B0"
-        }
-      },
-      {
-        "scope": "punctuation.definition.embedded.end.rxiv",
-        "settings": {
-          "foreground": "#4EC9B0"
-        }
-      },
-      {
-        "scope": "source.python.embedded.rxiv",
-        "settings": {
-          "foreground": "#D4D4D4"
-        }
-      },
-      {
-        "scope": "keyword.control.import.python.rxiv",
-        "settings": {
-          "foreground": "#C586C0",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "entity.name.type.module.python.rxiv",
-        "settings": {
-          "foreground": "#4FC1FF"
-        }
-      },
-      {
-        "scope": "keyword.control.variable.set.python.rxiv",
-        "settings": {
-          "foreground": "#9CDCFE",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "keyword.control.variable.get.python.rxiv",
-        "settings": {
-          "foreground": "#DCDCAA",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "keyword.control.variable.global.python.rxiv",
-        "settings": {
-          "foreground": "#FF6B6B",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "variable.other.readwrite.python.rxiv",
-        "settings": {
-          "foreground": "#9CDCFE"
-        }
-      },
-      {
-        "scope": "variable.other.readwrite.global.python.rxiv",
-        "settings": {
-          "foreground": "#FF8C94"
-        }
-      },
-      {
-        "scope": "keyword.operator.assignment.python.rxiv",
-        "settings": {
-          "foreground": "#D4D4D4"
-        }
-      },
-      {
-        "scope": "string.quoted.context.name.python.rxiv",
-        "settings": {
-          "foreground": "#CE9178"
-        }
-      },
-      {
-        "scope": "string.quoted.format.spec.python.rxiv",
-        "settings": {
-          "foreground": "#D7BA7D"
-        }
-      },
-      {
-        "scope": "keyword.control.conditional.python.rxiv",
-        "settings": {
-          "foreground": "#C586C0",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "string.quoted.double.conditional.python.rxiv",
-        "settings": {
-          "foreground": "#98C379"
-        }
-      },
-      {
-        "scope": "punctuation.separator.conditional.python.rxiv",
-        "settings": {
-          "foreground": "#D4D4D4"
-        }
       }
     ],
     "jsonValidation": [

--- a/syntaxes/rxiv-markdown.tmLanguage.json
+++ b/syntaxes/rxiv-markdown.tmLanguage.json
@@ -51,11 +51,6 @@
       "comment": "Citations like [@key] or [@key1; @key2]"
     },
     {
-      "name": "entity.name.tag.citation.rxiv",
-      "match": "@[a-zA-Z0-9_.-]+",
-      "comment": "Individual citation keys like @key"
-    },
-    {
       "name": "entity.name.tag.reference.rxiv",
       "match": "@(s?)((fig|table|eq|snote)):([a-zA-Z0-9_-]+)",
       "captures": {
@@ -64,6 +59,11 @@
         "4": {"name": "variable.other.constant.reference.rxiv"}
       },
       "comment": "Cross-references like @fig:label, @stable:label"
+    },
+    {
+      "name": "entity.name.tag.citation.rxiv",
+      "match": "@[a-zA-Z0-9_.-]+",
+      "comment": "Individual citation keys like @key"
     },
     {
       "name": "entity.name.tag.label-definition.rxiv",


### PR DESCRIPTION
Ships a coherent syntax-highlighting colour scheme for rxiv cross-references and fixes token colouring, released as v0.3.16.

## Changes
1. **Cross-reference colouring** — `@fig:label`, `@sfig:`, `@stable:`, `@snote:`, and `{#…}` definitions are colour-coded via `editor.tokenColorCustomizations` (contributed through `configurationDefaults`, the supported mechanism): type + `@`/`:` + supplementary `s` in one hue (`#C586C0`), label in another (`#D7BA7D`). The supplementary `s` now renders uniformly across `@stable`/`@sfig`/`@seq` and `@snote`.
2. **Grammar fix** — reordered so the cross-reference rule precedes the generic citation rule, which previously matched `@fig` as a citation and left `:label` unscoped (so the colour couldn't apply to uses, only to `{#…}` definitions). Safe: the cross-ref rule only matches `@<type>:`, so real citation keys still fall through.
3. **Apply contributed token colours** — moved the inert `contributes.tokenColors` block (not a supported contribution point) into `editor.tokenColorCustomizations`, so the authored colours for `<newpage>`, blindtext, and embedded Python/TeX now actually render. (Supersedes #16.)
4. **Release** — bumped to `0.3.16` with CHANGELOG.

Tagging `v0.3.16` after merge triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)