### PR TITLE
fix: apply contributed token colours via configurationDefaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 
 ### Added
 - **🎨 Cross-reference label colouring** - The label after the colon in cross-references and label definitions (e.g. `blabla` in `@fig:blabla`, `@snote:blabla`, `{#fig:blabla}`) is now colour-coded. The grammar already scoped it (`variable.other.constant.reference.rxiv` / `…label.rxiv`); this adds an `editor.tokenColorCustomizations` rule via `contributes.configurationDefaults` so it renders distinctly regardless of the active theme.
+- **🔧 Apply contributed token colours** - Moved the `contributes.tokenColors` rules into `editor.tokenColorCustomizations` under `configurationDefaults`. `contributes.tokenColors` is not a supported VS Code contribution point and had no effect, so the intended colours for `<newpage>`, blindtext placeholders, and embedded Python/TeX blocks were never applied; they now render as authored.
 
 ## [0.3.15] - 2025-12-09
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,157 @@
             "settings": {
               "foreground": "#CE9178"
             }
+          },
+          {
+            "scope": [
+              "markup.subscript",
+              "markup.superscript"
+            ],
+            "settings": {
+              "foreground": "#A0A0A0"
+            }
+          },
+          {
+            "scope": "keyword.control.newpage.rxiv",
+            "settings": {
+              "foreground": "#569CD6"
+            }
+          },
+          {
+            "scope": "keyword.control.placeholder.blindtext.rxiv",
+            "settings": {
+              "foreground": "#C586C0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "entity.name.function.blindtext.rxiv",
+            "settings": {
+              "foreground": "#DCDCAA"
+            }
+          },
+          {
+            "scope": "keyword.control.embedded.python.rxiv",
+            "settings": {
+              "foreground": "#4EC9B0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.control.embedded.tex.rxiv",
+            "settings": {
+              "foreground": "#FF7F50",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "source.tex.embedded.rxiv",
+            "settings": {
+              "foreground": "#D4D4D4"
+            }
+          },
+          {
+            "scope": "punctuation.definition.embedded.begin.rxiv",
+            "settings": {
+              "foreground": "#4EC9B0"
+            }
+          },
+          {
+            "scope": "punctuation.definition.embedded.end.rxiv",
+            "settings": {
+              "foreground": "#4EC9B0"
+            }
+          },
+          {
+            "scope": "source.python.embedded.rxiv",
+            "settings": {
+              "foreground": "#D4D4D4"
+            }
+          },
+          {
+            "scope": "keyword.control.import.python.rxiv",
+            "settings": {
+              "foreground": "#C586C0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "entity.name.type.module.python.rxiv",
+            "settings": {
+              "foreground": "#4FC1FF"
+            }
+          },
+          {
+            "scope": "keyword.control.variable.set.python.rxiv",
+            "settings": {
+              "foreground": "#9CDCFE",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.control.variable.get.python.rxiv",
+            "settings": {
+              "foreground": "#DCDCAA",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.control.variable.global.python.rxiv",
+            "settings": {
+              "foreground": "#FF6B6B",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "variable.other.readwrite.python.rxiv",
+            "settings": {
+              "foreground": "#9CDCFE"
+            }
+          },
+          {
+            "scope": "variable.other.readwrite.global.python.rxiv",
+            "settings": {
+              "foreground": "#FF8C94"
+            }
+          },
+          {
+            "scope": "keyword.operator.assignment.python.rxiv",
+            "settings": {
+              "foreground": "#D4D4D4"
+            }
+          },
+          {
+            "scope": "string.quoted.context.name.python.rxiv",
+            "settings": {
+              "foreground": "#CE9178"
+            }
+          },
+          {
+            "scope": "string.quoted.format.spec.python.rxiv",
+            "settings": {
+              "foreground": "#D7BA7D"
+            }
+          },
+          {
+            "scope": "keyword.control.conditional.python.rxiv",
+            "settings": {
+              "foreground": "#C586C0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "string.quoted.double.conditional.python.rxiv",
+            "settings": {
+              "foreground": "#98C379"
+            }
+          },
+          {
+            "scope": "punctuation.separator.conditional.python.rxiv",
+            "settings": {
+              "foreground": "#D4D4D4"
+            }
           }
+    
         ]
       }
     },
@@ -85,157 +235,6 @@
         "language": "rxiv-markdown",
         "scopeName": "source.rxiv-markdown",
         "path": "./syntaxes/rxiv-markdown.tmLanguage.json"
-      }
-    ],
-    "tokenColors": [
-      {
-        "scope": [
-          "markup.subscript",
-          "markup.superscript"
-        ],
-        "settings": {
-          "foreground": "#A0A0A0"
-        }
-      },
-      {
-        "scope": "keyword.control.newpage.rxiv",
-        "settings": {
-          "foreground": "#569CD6"
-        }
-      },
-      {
-        "scope": "keyword.control.placeholder.blindtext.rxiv",
-        "settings": {
-          "foreground": "#C586C0",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "entity.name.function.blindtext.rxiv",
-        "settings": {
-          "foreground": "#DCDCAA"
-        }
-      },
-      {
-        "scope": "keyword.control.embedded.python.rxiv",
-        "settings": {
-          "foreground": "#4EC9B0",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "keyword.control.embedded.tex.rxiv",
-        "settings": {
-          "foreground": "#FF7F50",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "source.tex.embedded.rxiv",
-        "settings": {
-          "foreground": "#D4D4D4"
-        }
-      },
-      {
-        "scope": "punctuation.definition.embedded.begin.rxiv",
-        "settings": {
-          "foreground": "#4EC9B0"
-        }
-      },
-      {
-        "scope": "punctuation.definition.embedded.end.rxiv",
-        "settings": {
-          "foreground": "#4EC9B0"
-        }
-      },
-      {
-        "scope": "source.python.embedded.rxiv",
-        "settings": {
-          "foreground": "#D4D4D4"
-        }
-      },
-      {
-        "scope": "keyword.control.import.python.rxiv",
-        "settings": {
-          "foreground": "#C586C0",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "entity.name.type.module.python.rxiv",
-        "settings": {
-          "foreground": "#4FC1FF"
-        }
-      },
-      {
-        "scope": "keyword.control.variable.set.python.rxiv",
-        "settings": {
-          "foreground": "#9CDCFE",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "keyword.control.variable.get.python.rxiv",
-        "settings": {
-          "foreground": "#DCDCAA",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "keyword.control.variable.global.python.rxiv",
-        "settings": {
-          "foreground": "#FF6B6B",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "variable.other.readwrite.python.rxiv",
-        "settings": {
-          "foreground": "#9CDCFE"
-        }
-      },
-      {
-        "scope": "variable.other.readwrite.global.python.rxiv",
-        "settings": {
-          "foreground": "#FF8C94"
-        }
-      },
-      {
-        "scope": "keyword.operator.assignment.python.rxiv",
-        "settings": {
-          "foreground": "#D4D4D4"
-        }
-      },
-      {
-        "scope": "string.quoted.context.name.python.rxiv",
-        "settings": {
-          "foreground": "#CE9178"
-        }
-      },
-      {
-        "scope": "string.quoted.format.spec.python.rxiv",
-        "settings": {
-          "foreground": "#D7BA7D"
-        }
-      },
-      {
-        "scope": "keyword.control.conditional.python.rxiv",
-        "settings": {
-          "foreground": "#C586C0",
-          "fontStyle": "bold"
-        }
-      },
-      {
-        "scope": "string.quoted.double.conditional.python.rxiv",
-        "settings": {
-          "foreground": "#98C379"
-        }
-      },
-      {
-        "scope": "punctuation.separator.conditional.python.rxiv",
-        "settings": {
-          "foreground": "#D4D4D4"
-        }
       }
     ],
     "jsonValidation": [


### PR DESCRIPTION
## What
Relocates all 23 `contributes.tokenColors` rules into `editor.tokenColorCustomizations` under `contributes.configurationDefaults`, and removes the now-empty `tokenColors` block.

## Why
`contributes.tokenColors` is **not a supported VS Code contribution point** — VS Code never reads it and the compiled extension does not apply it, so the intended colours for `<newpage>`, blindtext placeholders, and embedded Python/TeX blocks have never actually rendered. This moves them to the supported mechanism (the same one PR #15 uses for cross-reference labels), so they apply as authored.

## Notes
- Pure relocation: each rule's `scope`/`settings` is unchanged, only re-indented into the working location.
- **Stacked on #15** (base = `feat/colour-crossref-labels`). Merge #15 first, or retarget to `main` after it merges.
- Behaviour change: colours that were silently inactive will now appear. Worth a visual check against the active theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)