### PR TITLE
fix: namespace subscript/superscript scopes to stop global colour leak (v0.3.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "rxiv-maker" VS Code extension will be documented in 
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.17] - 2026-05-29
+
+### Fixed
+- **🔧 Subscript/superscript scope leak** - The token colour rule targeted the generic `markup.subscript` / `markup.superscript` TextMate scopes, which other grammars (standard Markdown, AsciiDoc, reStructuredText) also emit. Because `editor.tokenColorCustomizations` is contributed globally, this greyed out subscript/superscript text in every file type, not just rxiv documents. The scopes are now namespaced to `markup.subscript.rxiv` / `markup.superscript.rxiv`, and the grammar gained matching rules for `~subscript~` and `^superscript^`, so the colouring is both scoped to rxiv files and actually applied (the previous rule matched nothing the grammar emitted).
+
 ## [0.3.16] - 2026-05-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rxiv-maker",
   "displayName": "Rxiv-Maker",
   "description": "Enhanced toolkit for scientific manuscript authoring with rxiv-maker, including Python code execution, blindtext support, and comprehensive linting",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "publisher": "HenriquesLab",
   "icon": "icon.png",
   "license": "MIT",
@@ -90,8 +90,8 @@
           },
           {
             "scope": [
-              "markup.subscript",
-              "markup.superscript"
+              "markup.subscript.rxiv",
+              "markup.superscript.rxiv"
             ],
             "settings": {
               "foreground": "#A0A0A0"
@@ -237,7 +237,6 @@
               "foreground": "#D4D4D4"
             }
           }
-    
         ]
       }
     },

--- a/syntaxes/rxiv-markdown.tmLanguage.json
+++ b/syntaxes/rxiv-markdown.tmLanguage.json
@@ -165,6 +165,16 @@
       "comment": "Inline code with `code`"
     },
     {
+      "name": "markup.subscript.rxiv",
+      "match": "(?<!~)~([^~\\s]+)~(?!~)",
+      "comment": "Subscript text with ~text~ (e.g. H~2~O); single tilde, no spaces, avoids ~~strikethrough~~"
+    },
+    {
+      "name": "markup.superscript.rxiv",
+      "match": "\\^([^\\^\\s]+)\\^",
+      "comment": "Superscript text with ^text^ (e.g. E=mc^2^)"
+    },
+    {
       "name": "markup.bold.markdown",
       "match": "(\\*\\*)((?:[^*]|\\*(?!\\*))+)(\\*\\*)",
       "captures": {


### PR DESCRIPTION
## Summary

Addresses the **request-changes blocker** raised by the automated review on PR #16, which landed live on `main` when #15 was merged (v0.3.16) and #16's work was folded in.

The token colour rule targeted the **generic** `markup.subscript` / `markup.superscript` TextMate scopes. Because `editor.tokenColorCustomizations` is contributed globally via `configurationDefaults`, this greyed out subscript/superscript text in **every file type** (plain Markdown, AsciiDoc, reStructuredText), not just rxiv documents.

Investigating further, the rule was also **dead** inside `.rxm` files: the grammar emitted no subscript/superscript scopes at all, so nothing was ever coloured in rxiv documents either.

## Changes

- **Grammar** (`syntaxes/rxiv-markdown.tmLanguage.json`): added two rules emitting `markup.subscript.rxiv` and `markup.superscript.rxiv`, matching rxiv-maker's pandoc-style `~subscript~` (e.g. `H~2~O`) and `^superscript^` (e.g. `E=mc^2^`) per the README. The subscript pattern uses single-tilde with no spaces and negative lookarounds so it does not swallow `~~strikethrough~~`.
- **`package.json`**: renamed the colour-rule scopes to the `.rxiv`-namespaced names; removed a trailing-whitespace-only line; bumped version `0.3.16` → `0.3.17`.
- **CHANGELOG**: `[0.3.17]` entry.

Net effect: the colouring is now both scoped to rxiv files (no global leak) and actually applied (the grammar emits the scopes it targets).

## Verification

- Both JSON files parse.
- New regexes checked against the README examples: `H~2~O`, `CO~2~`, `E=mc^2^`, `x^n^` match; `~~strikethrough~~` and lone tildes correctly do not.
- No TypeScript touched.

## Deferred (lower-priority review notes, not addressed here)

- Light-theme contrast on the Dark+ hex palette.
- No opt-out setting for the contributed colours.
- Duplicate `entity.name.tag.citation.rxiv` rule name in the grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)