### PR TITLE
chore: scope subscript/superscript delimiters as punctuation.definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 ## [0.3.17] - 2026-05-29
 
 ### Fixed
-- **🔧 Subscript/superscript scope leak** - The token colour rule targeted the generic `markup.subscript` / `markup.superscript` TextMate scopes, which other grammars (standard Markdown, AsciiDoc, reStructuredText) also emit. Because `editor.tokenColorCustomizations` is contributed globally, this greyed out subscript/superscript text in every file type, not just rxiv documents. The scopes are now namespaced to `markup.subscript.rxiv` / `markup.superscript.rxiv`, and the grammar gained matching rules for `~subscript~` and `^superscript^`, so the colouring is both scoped to rxiv files and actually applied (the previous rule matched nothing the grammar emitted).
+- **🔧 Subscript/superscript scope leak** - The token colour rule targeted the generic `markup.subscript` / `markup.superscript` TextMate scopes, which other grammars (standard Markdown, AsciiDoc, reStructuredText) also emit. Because `editor.tokenColorCustomizations` is contributed globally, this greyed out subscript/superscript text in every file type, not just rxiv documents. The scopes are now namespaced to `markup.subscript.rxiv` / `markup.superscript.rxiv`, and the grammar gained matching rules for `~subscript~` and `^superscript^`, so the colouring is both scoped to rxiv files and actually applied (the previous rule matched nothing the grammar emitted). The `~`/`^` delimiters are also scoped as `punctuation.definition.{subscript,superscript}.{begin,end}.rxiv`, consistent with the bold/italic rules, so themes can style the delimiters independently of the content.
 
 ## [0.3.16] - 2026-05-29
 

--- a/syntaxes/rxiv-markdown.tmLanguage.json
+++ b/syntaxes/rxiv-markdown.tmLanguage.json
@@ -166,12 +166,20 @@
     },
     {
       "name": "markup.subscript.rxiv",
-      "match": "(?<!~)~([^~\\s]+)~(?!~)",
+      "match": "(?<!~)(~)([^~\\s]+)(~)(?!~)",
+      "captures": {
+        "1": {"name": "punctuation.definition.subscript.begin.rxiv"},
+        "3": {"name": "punctuation.definition.subscript.end.rxiv"}
+      },
       "comment": "Subscript text with ~text~ (e.g. H~2~O); single tilde, no spaces, avoids ~~strikethrough~~"
     },
     {
       "name": "markup.superscript.rxiv",
-      "match": "\\^([^\\^\\s]+)\\^",
+      "match": "(\\^)([^\\^\\s]+)(\\^)",
+      "captures": {
+        "1": {"name": "punctuation.definition.superscript.begin.rxiv"},
+        "3": {"name": "punctuation.definition.superscript.end.rxiv"}
+      },
       "comment": "Superscript text with ^text^ (e.g. E=mc^2^)"
     },
     {


### PR DESCRIPTION
## Summary

Optional polish flagged (and deferred) in the #17 review: the `~` / `^` subscript/superscript delimiters now get their own `punctuation.definition.{subscript,superscript}.{begin,end}.rxiv` scopes via `captures`, consistent with how the existing `markup.bold` / `markup.italic` rules scope their delimiters. This lets themes style the delimiters independently of the content; the default appearance is unchanged.

## Behaviour

Match behaviour is identical — only capture grouping was added. Verified the regexes still match `H~2~O`, `CO~2~`, `E=mc^2^`, `x^n^` and still ignore `~~strikethrough~~` and `[^1]` footnotes.

Folds into the unreleased `0.3.17` CHANGELOG entry; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)