### PR TITLE
chore: release v0.3.18 (svideo cross-reference support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 
 ## [Unreleased]
 
+## [0.3.18] - 2026-06-01
+
 ### Added
 - **🎬 Supplementary video cross-references (`svideo`)** - Added first-class support for the `svideo` cross-reference type introduced in rxiv-maker 1.20.0, mirroring the existing `snote` handling. `@svideo:label` references and `{#svideo:label url="..."}` label definitions now receive the same syntax highlighting (TextMate grammar), autocompletion (`@sv`/`@svideo` partial and full triggers, plus label suggestions), undefined-reference/duplicate-label diagnostics, and structure/citation validation as the other cross-reference types. `@svideo:` is recognised as a cross-reference (not flagged as an unknown citation), and the README cross-reference table documents it (`@svideo:label` → `\ref{svideo:label}`).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rxiv-maker",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rxiv-maker",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rxiv-maker",
   "displayName": "Rxiv-Maker",
   "description": "Enhanced toolkit for scientific manuscript authoring with rxiv-maker, including Python code execution, blindtext support, and comprehensive linting",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "publisher": "HenriquesLab",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cuts a patch release **v0.3.18** so the `svideo` / `@svideo:` / `{#svideo:}` cross-reference support (merged via #22) reaches users in a published release.

The last published release was **v0.3.16** (GitHub release marked Latest; Open VSX at 0.3.16). Both `v0.3.17` (subscript/superscript scope fix) and the `svideo` feature were sitting unreleased on `main`. This patch ships both.

## Changes
- Bump `version` to `0.3.18` in `package.json` and `package-lock.json`.
- Promote the `svideo` entry from `[Unreleased]` to a dated `[0.3.18]` CHANGELOG section.

## Verification
- `npm ci` — 0 vulnerabilities
- `npm run check-types` — pass
- `npm run lint` — pass
- `npm run package` (production esbuild) — pass
- `npm test` — pass (2 passing, 13 pending/skipped; exit 0)
- `vsce package` — produces `rxiv-maker-0.3.18.vsix` (1.42 MB, 15 files)
- Confirmed `svideo` present in grammar, 5 source validators/completions, and the production `dist/extension.js`.

## Release
Once merged, tag `v0.3.18` triggers `.github/workflows/release.yml`, which builds the `.vsix`, creates the GitHub Release, and publishes to the VS Code Marketplace + Open VSX (subject to `VSCE_PAT` / `OVSX_PAT` secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)